### PR TITLE
VectorEncode byte-aligned

### DIFF
--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -136,12 +136,11 @@ At a high level, the constructions in this document instantiate the following fu
 
 ## Common Functions {#common-func}
 
-The following function maps a vector of length `n` of coefficients modulo `q` to a large integer.
-Applying the technique from {{ELL2}}, where `r` is the large integer resulting from accumulating coefficients, we then choose `m` at random from `[0,floor((2^(b+t)-r)/(q^n))]`, where `b = ceil(n*log2(q))` and `t` is a security parameter, and return `r + m*q^(n)`.
-Notably, the random value `m` need not be transmitted alongside the encoded values.
-This results in encoded values whose statistical distance from uniform is at most `2^-t`.
-Notably, this statistical distance is unconditional; we hence fix `t=128`.
-This results in the encoding size increasing by `t` bits, i.e., 16 bytes.
+The following function `VectorEncode` maps a vector of length `n` of coefficients modulo `q` to a large integer `r` such that `r` is byte-aligned and (statistically close to) uniformly distributed.
+`VectorEncode` first accumulates the coefficients into a large integer `r` and then, applying the technique from {{ELL2}}, adds `m * q^n`,
+where `m` is chosen at random from `[0,floor((2^3072-r)/(q^n))]`.
+This results in an encoded output value byte-aligned to `384` bytes (the same size as the ML-KEM vector encoding)
+whose statistical distance from uniform is at most `2^-76`.
 
 ~~~
 VectorEncode(a):
@@ -154,6 +153,8 @@ VectorEncode(a):
    return r + m*q^n
 ~~~
 
+The following function `VectorDecode` inverts the above mapping.
+
 ~~~
 VectorDecode(r):
    r = r % q^n
@@ -163,7 +164,7 @@ VectorDecode(r):
    return a
 ~~~
 
-The following algorithm samples an uncompressed pre-image of a coefficient `c` at random, where `u` is the decompressed value of `c`.
+The following algorithm `SamplePreimage` samples an uncompressed pre-image of a coefficient `c` at random, where `u` is the decompressed value of `c`.
 It must take as input values of `u` that are output from `Decompress_d`.
 The mapping is based on the `Compress_d`, `Decompress_d` algorithms from (Section 4.2.1 {{FIPS203}}).
 
@@ -269,9 +270,9 @@ Kemeleon.DecodeCtxt(r):
 
 | Algorithm / Parameter    | Output size (bytes)  | Success probability  |
 | :----------------------- | -------------------: | -------------------: |
-| Kemeleon - ML-KEM512   | ek: 814, ctxt: 1172  | ek: 1.00, ctxt: 1.00 |
-| Kemeleon - ML-KEM768   | ek: 1204, ctxt: 1562 | ek: 1.00, ctxt: 1.00 |
-| Kemeleon - ML-KEM1024  | ek: 1594, ctxt: 1953 | ek: 1.00, ctxt: 1.00 |
+| Kemeleon - ML-KEM512     | ek: 800, ctxt: 1152  | ek: 1.00, ctxt: 1.00 |
+| Kemeleon - ML-KEM768     | ek: 1184, ctxt: 1536 | ek: 1.00, ctxt: 1.00 |
+| Kemeleon - ML-KEM1024    | ek: 1568, ctxt: 1920 | ek: 1.00, ctxt: 1.00 |
 {: #summary-encoding title="Summary of Kemeleon Properties"}
 
 # Additional Considerations for Applications {#considerations}

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -270,9 +270,9 @@ Kemeleon.DecodeCtxt(r):
 
 | Algorithm / Parameter    | Output size (bytes)  | Success probability  |
 | :----------------------- | -------------------: | -------------------: |
-| Kemeleon - ML-KEM512     | ek: 800, ctxt: 1152  | ek: 1.00, ctxt: 1.00 |
-| Kemeleon - ML-KEM768     | ek: 1184, ctxt: 1536 | ek: 1.00, ctxt: 1.00 |
-| Kemeleon - ML-KEM1024    | ek: 1568, ctxt: 1920 | ek: 1.00, ctxt: 1.00 |
+| Kemeleon - ML-KEM-512    | ek: 800, ctxt: 1152  | ek: 1.00, ctxt: 1.00 |
+| Kemeleon - ML-KEM-768    | ek: 1184, ctxt: 1536 | ek: 1.00, ctxt: 1.00 |
+| Kemeleon - ML-KEM-1024   | ek: 1568, ctxt: 1920 | ek: 1.00, ctxt: 1.00 |
 {: #summary-encoding title="Summary of Kemeleon Properties"}
 
 # Additional Considerations for Applications {#considerations}

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -139,18 +139,19 @@ At a high level, the constructions in this document instantiate the following fu
 The following function `VectorEncode` maps a vector of length `n` of coefficients modulo `q` to a large integer `r` such that `r` is byte-aligned and (statistically close to) uniformly distributed.
 `VectorEncode` first accumulates the coefficients into a large integer `r` and then, applying the technique from {{ELL2}}, adds `m * q^n`,
 where `m` is chosen at random from `[0,floor((2^3072-r)/(q^n))]`.
-This results in an encoded output value byte-aligned to `384` bytes (the same size as the ML-KEM vector encoding)
+This results in an encoded output value byte-aligned to `384` bytes (the same size as the standard ML-KEM vector encoding)
 whose statistical distance from uniform is at most `2^-76`.
 
 ~~~
 VectorEncode(a):
    r = 0
-   t = 128
-   b = ceil(n*log2(q))
+   t = 76   # stat. distance from uniform and byte-aligned
+   b = 2996 # ceil(n*log2(q))
    for i from 1 to n:
       r += q^(i-1)*a[i]
    m <--$ [0,...,floor((2^(b+t)-r)/(q^(n)))]
-   return r + m*q^n
+   r = r + m*q^n
+   return r
 ~~~
 
 The following function `VectorDecode` inverts the above mapping.


### PR DESCRIPTION
Addressing Dan Harkins' (CFRG, 27-Jan2026) points:

>   comment 1: t is a security parameter in VectorEncode(), It has a detailed
>         description in the common functions section, so don't hard code it.
>         Fixing it to 128 can be a recommendation but leave it up to the
>         application, not the specification. (And I'm not asking for any
>         cipher suites and IANA recommendations in your draft, just leave it
>         up to the user).
> 
>   comment 2: I know p*log2(m) is the same as log2(m^p) but your description
>         of b in VectorEncode() will lead to errors, I think. log2(q) is 11.703... but
>         FIPS 203 forbids floating point operations so if someone computes b
>         according to your notation-- b = n * log2(q)-- they'll get a different
>         number than if they computed q^n and did log2(q^n). And the latter
>         is correct, I think. Please change it to "b = log2(q^n)".
> 
>   Question: All the vectors being operated on now fixed at q^n and I would
>         expect that VectorEncode() would produce the same sized output for each
>         invocation regardless of parameter set. My version produces an encoded
>         vector that's 391 bytes. 391*k+32 works for ML-KEM-512 (814 bytes),
>         but according to table 1 it's one byte too many for ML-KEM-768 and 2
>         bytes too many for ML-KEM-1024. Am I doing something wrong or is
>         table 1 incorrect? 

Ensure VectorEncode is byte-aligned by setting `b+t = 3072 = 384B` (equal to ML-KEM's vector length), which implicitly sets the statistical distance to `2^-t = 2^-76`. Recall that statistical distance is unconditional, not relying on computation assumptions, so for any practical purpose, `2^-76` is small enough (and ensures Kemeleon implementations are interoperable).

Table 1 numers changed as a result (and fixed to byte-aligned values).