### PR TITLE
VectorEncodeR

### DIFF
--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -296,20 +296,40 @@ VectorEncodeR(a,k):
       r += q^(i-1)*a[i]
    if msb(r) == 1:
       return err
-   b = floor(log2(q^(k*n)))  # bit size of r, without msb(r) = 0
-   for j from b to (b + (8 - (b % 8)))-1  # remaining bits up to byte-aligned
+   r = IntegerRandomizeUnused(r,k)
+   return r
+~~~
+
+~~~
+VectorDecodeR(r,k):
+   IntegerClearUnused(r,k)
+   for i from 1 to k*n:
+      a[i] = r % q
+      r = r // q
+   return a
+~~~
+
+The following helper functions randomize resp. clear the unused bits of the top byte of an integer `r` (represented in network byte order).
+
+~~~
+IntegerRandomizeUnused(r,k):
+   b = floor(log2(q^(k*n)))    # bit size of r, without msb(r) = 0
+   x = 8 - (b % 8)             # number of unused bits
+   for j from b to b + x - 1   # remaining bits up to byte-aligned
       randbit <--$ [0,1]
       r = r + (randbit << j)
    return r
 ~~~
 
 ~~~
-VectorDecodeR(r,k):
-   <<TODO>> drop random top bits
-   for i from 1 to k*n:
-      a[i] = r % q
-      r = r // q
-   return a
+IntegerClearUnused(r,k):
+   b = floor(log2(q^(k*n)))    # bit size of target integer, without msb(r) = 0
+   x = 8 - (b % 8)             # number of randomized bits
+   r_bytes = to_bytes(r)       # network byte order
+   mask = 0xFF >> x
+   r_bytes[0] = r_bytes[0] & mask
+   r = from_bytes(r_bytes)
+   return r
 ~~~
 
 The encoding algorithms for public keys should handle errors accordingly, returning an error if `VectorEncode` returns an error.

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -348,7 +348,6 @@ Kemeleon.EncodeCtxtR(c = (c_1,c_2)):
    for i from 1 to n:
       if c_2[i] == 0:
          return err with prob. 1/ceil(q/(2^dv))
-   <<TODO>> make c_2 uniform random byte-aligned
    return concat(r,c_2)
 ~~~
 

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -112,9 +112,10 @@ A KEM consists of three algorithms:
 The following variables and functions are adopted from {{FIPS203}}:
 
 - `q = 3329`, `n = 256`
-- `Compress_d : x -> round((2^d/q)*x) mod 2^d` (Equation 4.7)
-- `Decompress_d : y -> round((q/2^d)*y)` (Equation 4.8)
-- remaining parameters `k`, `d_u`, `d_v`, etc. are defined by the respective ML-KEM parameter set -- this document writes `du` and `dv` in place of `d_u`, `d_v` in pseudocode
+- `Compress_d : x -> round((2^d/q)*x) mod 2^d` (Equation 4.7 {{FIPS203}})
+- `Decompress_d : y -> round((q/2^d)*y)` (Equation 4.8 {{FIPS203}})
+- `k = 2` for ML-KEM-512, `k = 3` for ML-KEM-768, `k = 4` for ML-KEM-1024
+- remaining parameters `d_u`, `d_v`, etc. are defined by the respective ML-KEM parameter set (Table 2 {{FIPS203}}) -- this document writes `du` and `dv` in place of `d_u`, `d_v` in pseudocode
 
 `ML-KEM.KeyGen()` (Section 7.1 {{FIPS203}}) produces an encapsulation key, `ek` and a decapsulation key, `dk`.
 Encapsulation keys consist of byte-encoded vectors of coefficients in Z_q, where each coefficient is encoded in 12 bits, together with a 32-byte seed for generating the matrix `A`.
@@ -280,11 +281,13 @@ This section contains additional considerations and comments related to using Ke
 
 ## Smaller Outputs from Rejection Sampling {#rejection-sampling}
 
-In applications willing to incur some probability of failure in encoding, a variant of the encoding algorithm that does not add the additional `m` value can be used.
-This results in smaller output sizes for public keys and ciphertexts.
-However, in this case it is no longer feasible to parallelize the encoding of the `k` polynomials; these must be treated as a single vector of `k*n` coefficients in order to achieve a reasonable rate of rejection.
-Therefore, this approach also requires arithmetic over larger integers (up to 1872B integers for ML-KEM1024).
+In applications willing to incur some probability of failure in encoding, the following variant of the encoding algorithms that result in smaller output sizes for encapsulation keys and ciphertexts can be used.
 In particular, the following algorithms can be used instead of `VectorEncode` and `VectorDecode` above.
+
+Encoding in this case accumulates all `k` polynomials into one large integer `r` and rejects if the most significant bit `msb(r)` is `1`.
+The resulting bitstring is padded with random bits for byte alignment.
+In this variant, it is no longer feasible to parallelize the encoding of the `k` polynomials; these must be treated as a single vector of `k*n` coefficients in order to achieve a reasonable rate of rejection.
+Therefore, this approach also requires arithmetic over larger integers (up to `ceil(log2(q^(4n))) = 11,982` bit integers for ML-KEM-1024, where `k = 4`).
 
 ~~~
 VectorEncodeR(a,k):
@@ -293,12 +296,16 @@ VectorEncodeR(a,k):
       r += q^(i-1)*a[i]
    if msb(r) == 1:
       return err
-   else:
-      return r
+   b = floor(log2(q^(k*n)))  # bit size of r, without msb(r) = 0
+   for j from b to (b + (8 - (b % 8)))-1  # remaining bits up to byte-aligned
+      randbit <--$ [0,1]
+      r = r + (randbit << j)
+   return r
 ~~~
 
 ~~~
 VectorDecodeR(r,k):
+   <<TODO>> drop random top bits
    for i from 1 to k*n:
       a[i] = r % q
       r = r // q
@@ -313,19 +320,20 @@ Kemeleon.EncodeCtxtR(c = (c_1,c_2)):
    u = Decompress_du(c_1)
    for i from 1 to k*n:
       u[i] = SamplePreimage(du,u[i],c_1[i])
-   r = VectorEncode(u)
+   r = VectorEncodeR(u)
    if r == err:
       return err
    for i from 1 to n:
       if c_2[1] == 0:
          return err with prob. 1/ceil(q/(2^dv))
+   <<TODO>> make c_2 uniform random byte-aligned
    return concat(r,c_2)
 ~~~
 
 ~~~
 Kemeleon.DecodeCtxtR(ec):
    r,c_2 = ec # c_2 is fixed length
-   u = VectorDecode(r)
+   u = VectorDecodeR(r)
    c_1 = Compress_du(u)
    return (c_1,c_2)
 ~~~

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -332,11 +332,11 @@ Kemeleon.DecodeCtxtR(ec):
 
 This variant of the encoding is as described in the original work {{GSV24}}, and has the following properties.
 
-| Algorithm / Parameter    | Output size (bytes)  | Success probability  | Additional considerations |
-| :----------------------- | -------------------: | -------------------: | ------------------------: |
-| Kemeleon - ML-KEM512     | ek: 781, ctxt: 877   | ek: 0.56, ctxt: 0.51 | Large int (750B) arithmetic |
-| Kemeleon - ML-KEM768     | ek: 1156, ctxt: 1252 | ek: 0.83, ctxt: 0.77 | Large int (1150B) arithmetic |
-| Kemeleon - ML-KEM1024    | ek: 1530, ctxt: 1658 | ek: 0.62, ctxt: 0.57 | Large int (1500B) arithmetic |
+| Algorithm / Parameter    | Output size (bytes)  | Success probability  | Additional considerations    |
+| :----------------------- | -------------------: | -------------------: | ------------------------:    |
+| Kemeleon - ML-KEM-512    | ek: 781, ctxt: 877   | ek: 0.56, ctxt: 0.51 | Large int (750B) arithmetic  |
+| Kemeleon - ML-KEM-768    | ek: 1156, ctxt: 1252 | ek: 0.83, ctxt: 0.77 | Large int (1150B) arithmetic |
+| Kemeleon - ML-KEM-1024   | ek: 1530, ctxt: 1658 | ek: 0.62, ctxt: 0.57 | Large int (1500B) arithmetic |
 {: #summary-alternate title="Summary of Alternate Encoding Properties"}
 
 ## Deterministic Encoding {#deterministic}

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -138,7 +138,7 @@ At a high level, the constructions in this document instantiate the following fu
 ## Common Functions {#common-func}
 
 The following function maps a vector of length `n` of coefficients modulo `q` to a large integer.
-Applying the technique from {{ELL2}}, where `r` is the large integer resulting from accumulating coefficients, we then choose `m` at random from `[0,floor((2^(b+t)-r)/(q^n))]`, where `b = ceil(n*log2(q))` and `t` is a security parameter, and return `r + m*q^(n)`.
+Applying the technique from (Section 3.4 {{ELL2}}), where `r` is the large integer resulting from accumulating coefficients, we then choose `m` at random from `[0,floor((2^(b+t)-r)/(q^n))]`, where `b = ceil(n*log2(q))` and `t` is a security parameter, and return `r + m*q^(n)`.
 Notably, the random value `m` need not be transmitted alongside the encoded values.
 This results in encoded values whose statistical distance from uniform is at most `2^-t`.
 Notably, this statistical distance is unconditional; we hence fix `t=128`.

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -278,7 +278,7 @@ Kemeleon.DecodeCtxt(r):
 
 This section contains additional considerations and comments related to using Kemeleon encodings in different applications.
 
-## Smaller Outputs from Rejection Sampling {#compressonly}
+## Smaller Outputs from Rejection Sampling {#rejection-sampling}
 
 In applications willing to incur some probability of failure in encoding, a variant of the encoding algorithm that does not add the additional `m` value can be used.
 This results in smaller output sizes for public keys and ciphertexts.
@@ -287,7 +287,7 @@ Therefore, this approach also requires arithmetic over larger integers (up to 18
 In particular, the following algorithms can be used instead of `VectorEncode` and `VectorDecode` above.
 
 ~~~
-VectorEncode(a,k):
+VectorEncodeR(a,k):
    r = 0
    for i from 1 to k*n:
       r += q^(i-1)*a[i]
@@ -298,7 +298,7 @@ VectorEncode(a,k):
 ~~~
 
 ~~~
-VectorDecode(r,k):
+VectorDecodeR(r,k):
    for i from 1 to k*n:
       a[i] = r % q
       r = r // q
@@ -309,7 +309,7 @@ The encoding algorithms for public keys should handle errors accordingly, return
 For ciphertexts, the second ciphertext component need not be decompressed, and rejection sampling can be used to retain uniformity instead.
 
 ~~~
-Kemeleon.EncodeCtxt(c = (c_1,c_2)):
+Kemeleon.EncodeCtxtR(c = (c_1,c_2)):
    u = Decompress_du(c_1)
    for i from 1 to k*n:
       u[i] = SamplePreimage(du,u[i],c_1[i])
@@ -323,7 +323,7 @@ Kemeleon.EncodeCtxt(c = (c_1,c_2)):
 ~~~
 
 ~~~
-Kemeleon.DecodeCtxt(ec):
+Kemeleon.DecodeCtxtR(ec):
    r,c_2 = ec # c_2 is fixed length
    u = VectorDecode(r)
    c_1 = Compress_du(u)

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -315,9 +315,11 @@ The following helper functions randomize resp. clear the unused bits of the top 
 IntegerRandomizeUnused(r,k):
    b = floor(log2(q^(k*n)))    # bit size of r, without msb(r) = 0
    x = 8 - (b % 8)             # number of unused bits
-   for j from b to b + x - 1   # remaining bits up to byte-aligned
-      randbit <--$ [0,1]
-      r = r + (randbit << j)
+   r_bytes = to_bytes(r)       # network byte order
+   mask = 0xFF << (8 - x) & 0xFF
+   rand = random_byte(1)       # sample 1 byte uniformly random
+   r_bytes[0] = r_bytes[0] | (rand & mask)
+   r = from_bytes(r_bytes)
    return r
 ~~~
 

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -282,10 +282,12 @@ This section contains additional considerations and comments related to using Ke
 ## Smaller Outputs from Rejection Sampling {#rejection-sampling}
 
 In applications willing to incur some probability of failure in encoding, the following variant of the encoding algorithms that result in smaller output sizes for encapsulation keys and ciphertexts can be used.
+The following algorithms make use of helper functions in {{helper-rejection}}.
+The encoding algorithms for encapsulation keys should handle errors accordingly, returning an error if `VectorEncodeR` returns an error.
 
 ~~~
 Kemeleon.EncodeEkR(ek = (t, rho)):
-   r = VectorEncode(t)
+   r = VectorEncodeR(t)
    return concat(r,rho)
 ~~~
 
@@ -296,7 +298,6 @@ Kemeleon.DecodeEkR(eek):
    return (t, rho)
 ~~~
 
-The encoding algorithms for encapsulation keys should handle errors accordingly, returning an error if `VectorEncodeR` returns an error.
 For ciphertexts, the second ciphertext component need not be decompressed, and rejection sampling can be used to retain uniformity instead.
 
 ~~~
@@ -321,7 +322,19 @@ Kemeleon.DecodeCtxtR(ec):
    return (c_1,c_2)
 ~~~
 
-In particular, the following algorithms `VectorEncodeR` and `VectorDecodeR` are used for vector encoding.
+This is a byte-aligned variant of the encoding as described in the original work {{GSV24}}, and has the following properties.
+
+| Algorithm / Parameter    | Output size (bytes)  | Success probability  | Additional considerations    |
+| :----------------------- | -------------------: | -------------------: | ------------------------:    |
+| Kemeleon - ML-KEM-512    | ek: 781, ctxt: 877   | ek: 0.56, ctxt: 0.51 | Large int (750B) arithmetic  |
+| Kemeleon - ML-KEM-768    | ek: 1156, ctxt: 1252 | ek: 0.83, ctxt: 0.77 | Large int (1150B) arithmetic |
+| Kemeleon - ML-KEM-1024   | ek: 1530, ctxt: 1658 | ek: 0.62, ctxt: 0.57 | Large int (1500B) arithmetic |
+{: #summary-alternate title="Summary of Alternate Encoding Properties"}
+
+
+### Helper Functions {#helper-rejection}
+
+The following algorithms `VectorEncodeR` and `VectorDecodeR` are used for vector encoding.
 
 Encoding in this case accumulates all `k` polynomials into one large integer `r` and rejects if the most significant bit `msb(r)` is `1`.
 The unused top bits of `r` (when represented in network byte order) are randomized to ensure a fully byte-aligned random output.
@@ -341,18 +354,19 @@ VectorEncodeR(a,k):
 
 ~~~
 VectorDecodeR(r,k):
-   IntegerClearUnused(r,k)
+   r = IntegerClearUnused(r,k)
    for i from 1 to k*n:
       a[i] = r % q
       r = r // q
    return a
 ~~~
 
-The following helper functions randomize resp. clear the unused bits of the top byte of an integer `r` (represented in network byte order).
+The following helper functions randomize resp. clear the unused bits of the top byte of an integer `r` (represented in network byte order) produced in `VectorEncodeR`.
 
 ~~~
 IntegerRandomizeUnused(r,k):
    b = floor(log2(q^(k*n)))    # bit size of r, without msb(r) = 0
+         # b=5990 if k=2, b=8986 if k=3, b=11981 if k=4
    x = 8 - (b % 8)             # number of unused bits
    r_bytes = to_bytes(r)       # network byte order
    mask = 0xFF << (8 - x) & 0xFF
@@ -365,6 +379,7 @@ IntegerRandomizeUnused(r,k):
 ~~~
 IntegerClearUnused(r,k):
    b = floor(log2(q^(k*n)))    # bit size of target integer, without msb(r) = 0
+         # b=5990 if k=2, b=8986 if k=3, b=11981 if k=4
    x = 8 - (b % 8)             # number of randomized bits
    r_bytes = to_bytes(r)       # network byte order
    mask = 0xFF >> x
@@ -372,16 +387,6 @@ IntegerClearUnused(r,k):
    r = from_bytes(r_bytes)
    return r
 ~~~
-
-This variant of the encoding is as described in the original work {{GSV24}}, and has the following properties.
-
-| Algorithm / Parameter    | Output size (bytes)  | Success probability  | Additional considerations    |
-| :----------------------- | -------------------: | -------------------: | ------------------------:    |
-| Kemeleon - ML-KEM-512    | ek: 781, ctxt: 877   | ek: 0.56, ctxt: 0.51 | Large int (750B) arithmetic  |
-| Kemeleon - ML-KEM-768    | ek: 1156, ctxt: 1252 | ek: 0.83, ctxt: 0.77 | Large int (1150B) arithmetic |
-| Kemeleon - ML-KEM-1024   | ek: 1530, ctxt: 1658 | ek: 0.62, ctxt: 0.57 | Large int (1500B) arithmetic |
-{: #summary-alternate title="Summary of Alternate Encoding Properties"}
-
 
 ### Compressing Encapsulation Keys without Rejection Sampling
 

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -282,7 +282,46 @@ This section contains additional considerations and comments related to using Ke
 ## Smaller Outputs from Rejection Sampling {#rejection-sampling}
 
 In applications willing to incur some probability of failure in encoding, the following variant of the encoding algorithms that result in smaller output sizes for encapsulation keys and ciphertexts can be used.
-In particular, the following algorithms can be used instead of `VectorEncode` and `VectorDecode` above.
+
+~~~
+Kemeleon.EncodeEkR(ek = (t, rho)):
+   r = VectorEncode(t)
+   return concat(r,rho)
+~~~
+
+~~~
+Kemeleon.DecodeEkR(eek):
+   r,rho = eek # rho and each r_i is fixed length
+   t = VectorDecodeR(r)
+   return (t, rho)
+~~~
+
+The encoding algorithms for encapsulation keys should handle errors accordingly, returning an error if `VectorEncodeR` returns an error.
+For ciphertexts, the second ciphertext component need not be decompressed, and rejection sampling can be used to retain uniformity instead.
+
+~~~
+Kemeleon.EncodeCtxtR(c = (c_1,c_2)):
+   u = Decompress_du(c_1)
+   for i from 1 to k*n:
+      u[i] = SamplePreimage(du,u[i],c_1[i])
+   r = VectorEncodeR(u)
+   if r == err:
+      return err
+   for i from 1 to n:
+      if c_2[i] == 0:
+         return err with prob. 1/ceil(q/(2^dv))
+   return concat(r,c_2)
+~~~
+
+~~~
+Kemeleon.DecodeCtxtR(ec):
+   r,c_2 = ec              # c_2 is fixed length
+   u = VectorDecodeR(r)
+   c_1 = Compress_du(u)
+   return (c_1,c_2)
+~~~
+
+In particular, the following algorithms `VectorEncodeR` and `VectorDecodeR` are used for vector encoding.
 
 Encoding in this case accumulates all `k` polynomials into one large integer `r` and rejects if the most significant bit `msb(r)` is `1`.
 The unused top bits of `r` (when represented in network byte order) are randomized to ensure a fully byte-aligned random output.
@@ -334,31 +373,6 @@ IntegerClearUnused(r,k):
    return r
 ~~~
 
-The encoding algorithms for public keys should handle errors accordingly, returning an error if `VectorEncode` returns an error.
-For ciphertexts, the second ciphertext component need not be decompressed, and rejection sampling can be used to retain uniformity instead.
-
-~~~
-Kemeleon.EncodeCtxtR(c = (c_1,c_2)):
-   u = Decompress_du(c_1)
-   for i from 1 to k*n:
-      u[i] = SamplePreimage(du,u[i],c_1[i])
-   r = VectorEncodeR(u)
-   if r == err:
-      return err
-   for i from 1 to n:
-      if c_2[i] == 0:
-         return err with prob. 1/ceil(q/(2^dv))
-   return concat(r,c_2)
-~~~
-
-~~~
-Kemeleon.DecodeCtxtR(ec):
-   r,c_2 = ec              # c_2 is fixed length
-   u = VectorDecodeR(r)
-   c_1 = Compress_du(u)
-   return (c_1,c_2)
-~~~
-
 This variant of the encoding is as described in the original work {{GSV24}}, and has the following properties.
 
 | Algorithm / Parameter    | Output size (bytes)  | Success probability  | Additional considerations    |
@@ -385,7 +399,7 @@ See {{randomness-security}} for relevant discussion on keeping this randomness s
 
 ## Relation to Hash-to-Curve {#hash-to-curve}
 
-While the functionality of Kemeleon is similar to hash-to-curve {{RFC9380}} (mapping arbitrary byte strings to public keys/ciphertexts), the applications where hash-to-curve is used do not immediately follow in the KEM-based setting because having such an encapsulation key (without `dk`) or ciphertext (without `dk` or `ek`) does not appear to provide the same functionality, since it is not clear how to continue working with the element in the same way that can be done with an elliptic curve point.
+While the functionality of Kemeleon is similar to hash-to-curve {{RFC9380}} (mapping arbitrary byte strings to encapsulation keys/ciphertexts), the applications where hash-to-curve is used do not immediately follow in the KEM-based setting because having such an encapsulation key (without `dk`) or ciphertext (without `dk` or `ek`) does not appear to provide the same functionality, since it is not clear how to continue working with the element in the same way that can be done with an elliptic curve point.
 
 ## Modifying ML-KEM Algorithms {#direct-generation}
 
@@ -416,7 +430,7 @@ This section contains additional security considerations about the Kemeleon enco
 
 ## Computational Assumptions {#assumptions}
 In general, the obfuscation properties of the Kemeleon encodings depend on module LWE assumptions similar to those underlying the IND-CCA security of ML-KEM; see {{GSV24}} for the detailed security analysis of the original Kemeleon encoding.
-In particular, the notions of public key and ciphertext uniformity capture the indistinguishability of Kemeleon-encoded encapsulation keys and ciphertexts from random bitstrings, respectively.
+In particular, the notions of public/encapsulation key and ciphertext uniformity capture the indistinguishability of Kemeleon-encoded encapsulation keys and ciphertexts from random bitstrings, respectively.
 Both require the module LWE assumption to hold in order for Kemeleon to maintain its uniformity properties.
 Furthermore, distinguishing a pair of a Kemeleon-encoded encapsulation key and a Kemeleon-encoded ciphertext from uniformly random bitstrings also reduces to a module LWE assumption.
 

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -382,6 +382,14 @@ This variant of the encoding is as described in the original work {{GSV24}}, and
 | Kemeleon - ML-KEM-1024   | ek: 1530, ctxt: 1658 | ek: 0.62, ctxt: 0.57 | Large int (1500B) arithmetic |
 {: #summary-alternate title="Summary of Alternate Encoding Properties"}
 
+
+### Compressing Encapsulation Keys without Rejection Sampling
+
+Applications merely interested in compressing encapsulation keys may use `EncodeEkR` and `DecodeEkR` without rejection and random padding in `VectorEncodeR`.
+The resulting encoded encapsulation keys will NOT be uniformly random, but have smaller output size as in {{summary-alternate}}.
+
+
+
 ## Deterministic Encoding {#deterministic}
 
 The randomness used in `Kemeleon` ciphertext encodings MAY be derived in a deterministic manner.

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -346,7 +346,7 @@ Kemeleon.EncodeCtxtR(c = (c_1,c_2)):
    if r == err:
       return err
    for i from 1 to n:
-      if c_2[1] == 0:
+      if c_2[i] == 0:
          return err with prob. 1/ceil(q/(2^dv))
    <<TODO>> make c_2 uniform random byte-aligned
    return concat(r,c_2)

--- a/draft-irtf-cfrg-kemeleon.md
+++ b/draft-irtf-cfrg-kemeleon.md
@@ -285,7 +285,7 @@ In applications willing to incur some probability of failure in encoding, the fo
 In particular, the following algorithms can be used instead of `VectorEncode` and `VectorDecode` above.
 
 Encoding in this case accumulates all `k` polynomials into one large integer `r` and rejects if the most significant bit `msb(r)` is `1`.
-The resulting bitstring is padded with random bits for byte alignment.
+The unused top bits of `r` (when represented in network byte order) are randomized to ensure a fully byte-aligned random output.
 In this variant, it is no longer feasible to parallelize the encoding of the `k` polynomials; these must be treated as a single vector of `k*n` coefficients in order to achieve a reasonable rate of rejection.
 Therefore, this approach also requires arithmetic over larger integers (up to `ceil(log2(q^(4n))) = 11,982` bit integers for ML-KEM-1024, where `k = 4`).
 
@@ -354,7 +354,7 @@ Kemeleon.EncodeCtxtR(c = (c_1,c_2)):
 
 ~~~
 Kemeleon.DecodeCtxtR(ec):
-   r,c_2 = ec # c_2 is fixed length
+   r,c_2 = ec              # c_2 is fixed length
    u = VectorDecodeR(r)
    c_1 = Compress_du(u)
    return (c_1,c_2)


### PR DESCRIPTION
Renaming, adding explicit EncodeEk/DecodeEk algorithms (as they differ), padding with random to make outputs byte-aligned; plus a comment on using this version just for compression.